### PR TITLE
RedisToGoの代わりにHeroku Redisを利用する

### DIFF
--- a/app.json
+++ b/app.json
@@ -36,7 +36,7 @@
     ],
     "addons": [
         {
-            "plan": "redistogo:nano"
+            "plan": "heroku-redis:hobby-dev"
         },
         {
             "plan": "papertrail:choklad"

--- a/lib/cache.rb
+++ b/lib/cache.rb
@@ -2,7 +2,7 @@ require 'time'
 require 'redis'
 
 module Cache
-  REDIS_URL = ENV['REDISTOGO_URL'] || "redis://127.0.0.1:6379/0"
+  REDIS_URL = ENV['REDIS_URL'] || "redis://127.0.0.1:6379/0"
   KEY_PREFIX = 'utsushie-'
 
   def self.set(key)


### PR DESCRIPTION
## 変更点
- `app.json` で指定しているRedis系add-onをHeroku Redisに変更
- RedisのURLを指定する環境変数を `REDIS_URL` に変更