### PR TITLE
絵文字 URL を open 出来なくて、全体的に動かなくなっていた

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -83,7 +83,7 @@ class App < Sinatra::Base
       # SlackからDLした絵文字画像を保存するフォルダを準備
       Dir.mkdir(IMAGE_BUFFER_DIR) if not Dir.exist?(IMAGE_BUFFER_DIR)
 
-      open(emoji.url) do |file|
+      URI.open(emoji.url) do |file|
         open(path, "w+b") do |out|
           out.write(file.read)
         end


### PR DESCRIPTION
@FromAtom https://github.com/FromAtom/Utsushie-Stream/compare/26166a1d92c6d159a1e24fadeecd5f54edc97f54...7c33e242785238ac7b2a743a617b485bbec34b79 をデプロイしたら、以下のエラーが発生し絵文字を登録できなくなりました。heroku-22 Stack です。

```
2022-08-29T02:38:05.391962+00:00 heroku[web.1]: State changed from starting to up
2022-08-29T02:39:17.773999+00:00 app[web.1]: 2022-08-29 02:39:17 - Errno::ENOENT - No such file or directory @ rb_sysopen - https://emoji.slack-edge.com/T02DQ8HS2/testtest/c03930fd94785ddf.png:
2022-08-29T02:39:17.774015+00:00 app[web.1]: /app/app.rb:86:in `initialize'
2022-08-29T02:39:17.774016+00:00 app[web.1]: /app/app.rb:86:in `open'
2022-08-29T02:39:17.774016+00:00 app[web.1]: /app/app.rb:86:in `add_emoji'
2022-08-29T02:39:17.774017+00:00 app[web.1]: /app/app.rb:60:in `block in <class:App>'
```

Gem の依存関係が変化し、`#open` が指し示すメソッドが [Kernel.#open](https://docs.ruby-lang.org/ja/3.1/method/Kernel/m/open.html) に変わったのかもしれません。明示的に [URI.open](https://docs.ruby-lang.org/ja/3.1/method/URI/s/open.html) を使うようにしました。

レビューお願いします。:pray:

